### PR TITLE
(#28) Add changeset for Dropdown component

### DIFF
--- a/.changeset/dropdown-component.md
+++ b/.changeset/dropdown-component.md
@@ -1,0 +1,5 @@
+---
+'@nciocpl/react-components': minor
+---
+
+Add `Dropdown` (NCIDS Select) component. Wraps a native `<select>` with USWDS styling and forwards standard form props for use as a controlled or uncontrolled input.


### PR DESCRIPTION
## Summary

PR #28 (Dropdown component) merged without a changeset, so the new component would not appear in the next CHANGELOG. This adds a `minor` changeset crediting the Dropdown work so the 0.1.1 release notes are complete.

## Test plan

- [ ] Confirm `.changeset/dropdown-component.md` is the only file added
- [ ] After this is merged, the upcoming `develop -> main` PR should carry both this changeset and the existing `fix-package-exports-and-styles.md`